### PR TITLE
add GetLastSupportedVersion

### DIFF
--- a/LeagueToolkit/Helpers/FileVersionProvider.cs
+++ b/LeagueToolkit/Helpers/FileVersionProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace LeagueToolkit.Helpers
 {
@@ -37,5 +37,7 @@ namespace LeagueToolkit.Helpers
         };
 
         public static Version[] GetSupportedVersions(LeagueFileType fileType) => SUPPORTED_VERSIONS[fileType];
+
+        public static Version GetLastSupportedVersion(LeagueFileType fileType) => GetSupportedVersions(fileType)?.OrderByDescending(x => x)?.FirstOrDefault();
     }
 }

--- a/LeagueToolkit/IO/PropertyBin/BinTree.cs
+++ b/LeagueToolkit/IO/PropertyBin/BinTree.cs
@@ -82,7 +82,7 @@ namespace LeagueToolkit.IO.PropertyBin
 
         public void Write(Stream stream, Version version = null)
         {
-            if (version != null)
+            if (version == null)
                 version = FileVersionProvider.GetLastSupportedVersion(LeagueFileType.PropertyBin);
 
             using (BinaryWriter bw = new BinaryWriter(stream))

--- a/LeagueToolkit/IO/PropertyBin/BinTree.cs
+++ b/LeagueToolkit/IO/PropertyBin/BinTree.cs
@@ -1,4 +1,5 @@
-﻿using LeagueToolkit.Helpers.Exceptions;
+﻿using LeagueToolkit.Helpers;
+using LeagueToolkit.Helpers.Exceptions;
 using LeagueToolkit.Helpers.Extensions;
 using System;
 using System.Collections.Generic;
@@ -74,12 +75,16 @@ namespace LeagueToolkit.IO.PropertyBin
             }
         }
 
-        public void Write(string fileLocation, Version version)
+        public void Write(string fileLocation, Version version = null)
         {
-            Write(File.OpenWrite(fileLocation), version);
+            Write(File.OpenWrite(fileLocation), version ?? FileVersionProvider.GetLastSupportedVersion(LeagueFileType.PropertyBin));
         }
-        public void Write(Stream stream, Version version)
+
+        public void Write(Stream stream, Version version = null)
         {
+            if (version != null)
+                version = FileVersionProvider.GetLastSupportedVersion(LeagueFileType.PropertyBin);
+
             using (BinaryWriter bw = new BinaryWriter(stream))
             {
                 bw.Write(Encoding.ASCII.GetBytes("PROP"));


### PR DESCRIPTION
Adds a function that returns the latest supported version for the given type.

It is deliberately used "OrderByDescending" and "FirstOrDefault" instead of "Last" to make sure that the list is sorted.