### PR TITLE
fix build warnings

### DIFF
--- a/LeagueToolkit/Helpers/Structures/Color.cs
+++ b/LeagueToolkit/Helpers/Structures/Color.cs
@@ -202,10 +202,7 @@ namespace LeagueToolkit.Helpers.Structures
 
         public override bool Equals(object obj)
         {
-            if (obj is null) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Color)obj);
+            return obj is Color other && Equals(other);
         }
 
         public override int GetHashCode()

--- a/LeagueToolkit/Helpers/Structures/Color.cs
+++ b/LeagueToolkit/Helpers/Structures/Color.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace LeagueToolkit.Helpers.Structures
 {
-    public struct Color: IEquatable<Color>
+    public struct Color : IEquatable<Color>
     {
         public static readonly Color Zero = new Color(0, 0, 0, 0);
 
@@ -98,7 +96,7 @@ namespace LeagueToolkit.Helpers.Structures
             int formatSize = FormatSize(format);
             byte[] colorBuffer = new byte[formatSize];
 
-            if(format == ColorFormat.RgbU8)
+            if (format == ColorFormat.RgbU8)
             {
                 colorBuffer[0] = (byte)(this.R * 255);
                 colorBuffer[1] = (byte)(this.G * 255);
@@ -124,7 +122,7 @@ namespace LeagueToolkit.Helpers.Structures
                 colorBuffer[2] = (byte)(this.R * 255);
                 colorBuffer[3] = (byte)(this.A * 255);
             }
-            else if(format == ColorFormat.RgbF32)
+            else if (format == ColorFormat.RgbF32)
             {
                 Buffer.BlockCopy(BitConverter.GetBytes(this.R), 0, colorBuffer, sizeof(float) * 0, sizeof(float));
                 Buffer.BlockCopy(BitConverter.GetBytes(this.G), 0, colorBuffer, sizeof(float) * 1, sizeof(float));
@@ -160,7 +158,7 @@ namespace LeagueToolkit.Helpers.Structures
             {
                 return string.Format("{0} {1} {2}", (byte)(this.R * 255), (byte)(this.G * 255), (byte)(this.B * 255));
             }
-            else if(format == ColorFormat.RgbaU8)
+            else if (format == ColorFormat.RgbaU8)
             {
                 return string.Format("{0} {1} {2} {3}", (byte)(this.R * 255), (byte)(this.G * 255), (byte)(this.B * 255), (byte)(this.B * 255));
             }
@@ -200,6 +198,19 @@ namespace LeagueToolkit.Helpers.Structures
                 this.G == other.G &&
                 this.B == other.B &&
                 this.A == other.A;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Color)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(R, G, B, A);
         }
 
         public static bool operator ==(Color a, Color b)

--- a/LeagueToolkit/IO/WadFile/WadBuilder.cs
+++ b/LeagueToolkit/IO/WadFile/WadBuilder.cs
@@ -14,7 +14,7 @@ namespace LeagueToolkit.IO.WadFile
 
         private Dictionary<ulong, WadEntryBuilder> _entries = new();
 
-        private bool _isDisposed;
+        private bool _disposedValue;
 
         public WadBuilder()
         {
@@ -146,14 +146,21 @@ namespace LeagueToolkit.IO.WadFile
             this._entries.Remove(xxhash);
         }
 
-        public void Dispose()
+        public void Dispose() => Dispose(true);
+
+        protected virtual void Dispose(bool disposing)
         {
-            if(this._isDisposed is false)
+            if (!_disposedValue)
             {
-                foreach(var entry in this._entries)
+                if (disposing)
                 {
-                    entry.Value.DataStream.Dispose();
+                    foreach (var entry in this._entries)
+                    {
+                        entry.Value.DataStream.Dispose();
+                    }
                 }
+
+                _disposedValue = true;
             }
         }
     }


### PR DESCRIPTION
Fix the build warnings from `WadBuilder` (CS0649) and `Color` (CS0660 and CS0661).

Btw. `CSharpImageLibrary` has added a few more warnings since there is no netStandard support. Apart from that, it is no longer supported and we should use something else if necessary.