### PR TITLE
extend WithGenericDataStream with additional call options

### DIFF
--- a/LeagueToolkit/IO/WadFile/WadEntryBuilder.cs
+++ b/LeagueToolkit/IO/WadFile/WadEntryBuilder.cs
@@ -95,9 +95,12 @@ namespace LeagueToolkit.IO.WadFile
 
             return WithGenericDataStream(filePath, stream);
         }
-        public WadEntryBuilder WithGenericDataStream(string path, Stream stream)
+
+        public WadEntryBuilder WithGenericDataStream(LeagueFileType fileType, Stream stream) => WithGenericDataStream($".{Utilities.GetExtension(fileType)}", stream);
+        public WadEntryBuilder WithGenericDataStream(string path, Stream stream) => WithGenericDataStream(Utilities.GetExtensionWadCompressionType(Path.GetExtension(path)), stream);
+        public WadEntryBuilder WithGenericDataStream(WadEntryType entryType, Stream stream)
         {
-            this.EntryType = Utilities.GetExtensionWadCompressionType(Path.GetExtension(path));
+            this.EntryType = entryType;
             this.DataStream = stream;
             this._isGenericDataStream = true;
             this.Checksum = new byte[8];


### PR DESCRIPTION
`WithGenericDataStream` is perfect to write a stream into the wad without knowing how to compress the object. However, it is necessary to specify the path. Unfortunately this is not always known. Therefore I extended the call a little bit and added some more possibilities without changing the old functionality.