### PR TITLE
Fix all usages of File.OpenWrite

### DIFF
--- a/LeagueToolkit.Tests/WadTests.cs
+++ b/LeagueToolkit.Tests/WadTests.cs
@@ -103,7 +103,7 @@ namespace LeagueToolkit.Tests
                 string entryFileName = "temp/" + entry.XXHash + "." + Utilities.GetExtension(Utilities.GetExtensionType(entryDecompressedStream));
 
                 // Extract entry data to temporary file
-                using (FileStream writeEntryFileStream = File.OpenWrite(entryFileName))
+                using (FileStream writeEntryFileStream = File.Create(entryFileName))
                 {
                     entry.GetDataHandle().GetDecompressedStream().CopyTo(writeEntryFileStream);
                 }

--- a/LeagueToolkit/IO/LightGrid/LightGridFile.cs
+++ b/LeagueToolkit/IO/LightGrid/LightGridFile.cs
@@ -81,7 +81,7 @@ namespace LeagueToolkit.IO.LightGrid
 
         public void WriteTexture(string fileLocation)
         {
-            using (BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileLocation)))
+            using (BinaryWriter bw = new BinaryWriter(File.Create(fileLocation)))
             {
                 bw.Write((byte)0); //ID Length
                 bw.Write((byte)0); //ColorMap Type

--- a/LeagueToolkit/IO/WadFile/WadBuilder.cs
+++ b/LeagueToolkit/IO/WadFile/WadBuilder.cs
@@ -42,7 +42,7 @@ namespace LeagueToolkit.IO.WadFile
             return this;
         }
 
-        public void Build(string fileLocation) => Build(File.OpenWrite(fileLocation), false);
+        public void Build(string fileLocation) => Build(File.Create(fileLocation), false);
         public void Build(Stream stream, bool leaveOpen)
         {
             using Wad wad = new();

--- a/LeagueToolkit/IO/WorldDescription/WorldDescriptionFile.cs
+++ b/LeagueToolkit/IO/WorldDescription/WorldDescriptionFile.cs
@@ -15,7 +15,7 @@ namespace LeagueToolkit.IO.WorldDescription
         public List<WorldDescriptionObject> Objects { get; set; } = new List<WorldDescriptionObject>();
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public WorldDescriptionFile() { }
 
@@ -46,7 +46,7 @@ namespace LeagueToolkit.IO.WorldDescription
         /// <param name="fileLocation">The location to write to</param>
         public void Write(string fileLocation)
         {
-            Write(File.OpenWrite(fileLocation));
+            Write(File.Create(fileLocation));
         }
 
         /// <summary>

--- a/LeagueToolkit/Meta/Dump/MetaDump.cs
+++ b/LeagueToolkit/Meta/Dump/MetaDump.cs
@@ -18,11 +18,11 @@ namespace LeagueToolkit.Meta.Dump
 
         public void WriteMetaClasses(string fileLocation, ICollection<string> classNames, ICollection<string> propertyNames)
         {
-            WriteMetaClasses(File.OpenWrite(fileLocation), classNames, propertyNames);
+            WriteMetaClasses(File.Create(fileLocation), classNames, propertyNames);
         }
         public void WriteMetaClasses(string fileLocation, Dictionary<uint, string> classNames, Dictionary<uint, string> propertyNames)
         {
-            WriteMetaClasses(File.OpenWrite(fileLocation), classNames, propertyNames);
+            WriteMetaClasses(File.Create(fileLocation), classNames, propertyNames);
         }
         public void WriteMetaClasses(Stream stream, ICollection<string> classNames, ICollection<string> propertyNames)
         {
@@ -156,9 +156,9 @@ namespace LeagueToolkit.Meta.Dump
         }
 
         private void WriteProperty(StreamWriter sw,
-            string classHash, MetaDumpClass dumpClass, 
+            string classHash, MetaDumpClass dumpClass,
             string propertyHash, MetaDumpProperty property,
-            bool isPublic, 
+            bool isPublic,
             Dictionary<uint, string> classNames, Dictionary<uint, string> propertyNames)
         {
             WritePropertyAttribute(sw, propertyHash, property, classNames, propertyNames);


### PR DESCRIPTION
`File.OpenWrite` is almost never something you want: It creates a file if it doesn't exist (usually wanted), and opens an existing file if one exists (also usually wanted), but *does not truncate the file*.
That means that every write (or even when writing nothing) file contents from an existing file will be left-over. This may or may not be an issue with reading, but it definitely is not intended and will cause issues whenever the entire file is used for any operation (packing it, running a checksum, etc.).