### PR TITLE
replace CSharpImageLibrary with ImageSharp

### DIFF
--- a/LeagueToolkit.IO.Extensions/LeagueToolkit.IO.Extensions.csproj
+++ b/LeagueToolkit.IO.Extensions/LeagueToolkit.IO.Extensions.csproj
@@ -22,8 +22,8 @@
 
   <!-- package references -->
   <ItemGroup>
-    <PackageReference Include="CSharpImageLibrary" Version="4.2.0" />
     <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0020" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
   </ItemGroup>
 
   <!-- project references -->


### PR DESCRIPTION
Since `KFreon/CSharpImageLibrary` is actually already obsolete (the repro is even archived) I replaced it with `ImageSharp` which is still under active development.

When rebuilding `AssignMaterialTexture` I kept to the base implementation as it was before the integration of CSharpImageLibrary.