### PR TITLE
feat: Use System.Text.Json instead of Newtonsoft.Json for `MetaDump`

### DIFF
--- a/src/LeagueToolkit/LeagueToolkit.csproj
+++ b/src/LeagueToolkit/LeagueToolkit.csproj
@@ -31,7 +31,6 @@
     </PackageReference>
     <PackageReference Include="FlatSharp.Runtime" Version="7.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" Condition="'$(Configuration)'=='DEBUG'" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="XXHash3.NET" Version="1.2.2" />
     <PackageReference Include="ZstdSharp.Port" Version="0.6.1" />
   </ItemGroup>

--- a/src/LeagueToolkit/Meta/Dump/MetaDumpClass.cs
+++ b/src/LeagueToolkit/Meta/Dump/MetaDumpClass.cs
@@ -1,39 +1,41 @@
 ﻿using CommunityToolkit.Diagnostics;
-using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace LeagueToolkit.Meta.Dump
 {
     public sealed class MetaDumpClass
     {
-        [JsonProperty(PropertyName = "alignment")]
+        [JsonInclude]
         public uint Alignment { get; private set; }
 
-        [JsonProperty(PropertyName = "base")]
+        [JsonInclude]
         public string Base { get; private set; }
 
-        [JsonProperty(PropertyName = "defaults")]
-        public Dictionary<string, object> Defaults { get; private set; }
+        [JsonInclude]
+        public Dictionary<string, JsonElement> Defaults { get; private set; }
 
-        [JsonProperty(PropertyName = "fn")]
+        [JsonPropertyName("fn")]
+        [JsonInclude]
         public MetaDumpClassFunctions Functions { get; private set; }
 
-        [JsonProperty(PropertyName = "is")]
+        [JsonInclude]
         public MetaDumpClassIs Is { get; private set; }
 
-        [JsonProperty(PropertyName = "properties")]
+        [JsonInclude]
         public Dictionary<string, MetaDumpProperty> Properties { get; private set; }
 
-        [JsonProperty(PropertyName = "secondary_bases")]
+        [JsonPropertyName("secondary_bases")]
+        [JsonInclude]
         public Dictionary<string, uint> SecondaryBases { get; private set; }
 
-        [JsonProperty(PropertyName = "secondary_children")]
+        [JsonPropertyName("secondary_children")]
+        [JsonInclude]
         public Dictionary<string, uint> SecondaryChildren { get; private set; }
 
-        [JsonProperty(PropertyName = "size")]
+        [JsonInclude]
         public uint Size { get; private set; }
 
         // TODO: Cleanup
@@ -108,40 +110,46 @@ namespace LeagueToolkit.Meta.Dump
 
     public sealed class MetaDumpClassFunctions
     {
-        [JsonProperty(PropertyName = "constructor")]
+        [JsonInclude]
         public string Constructor { get; private set; }
 
-        [JsonProperty(PropertyName = "destructor")]
+        [JsonInclude]
         public string Destructor { get; private set; }
 
-        [JsonProperty(PropertyName = "inplace_constructor")]
+        [JsonPropertyName("inplace_constructor")]
+        [JsonInclude]
         public string InplaceConstructor { get; private set; }
 
-        [JsonProperty(PropertyName = "inplace_destructor")]
+        [JsonPropertyName("inplace_destructor")]
+        [JsonInclude]
         public string InplaceDestructor { get; private set; }
 
-        [JsonProperty(PropertyName = "register")]
+        [JsonInclude]
         public string Register { get; private set; }
 
-        [JsonProperty(PropertyName = "upcast_secondary")]
+        [JsonPropertyName("upcast_secondary")]
+        [JsonInclude]
         public string UpcastSecondary { get; private set; }
     }
 
     public sealed class MetaDumpClassIs
     {
-        [JsonProperty(PropertyName = "interface")]
+        [JsonInclude]
         public bool Interface { get; private set; }
 
-        [JsonProperty(PropertyName = "property_base")]
+        [JsonPropertyName("property_base")]
+        [JsonInclude]
         public bool PropertyBase { get; private set; }
 
-        [JsonProperty(PropertyName = "secondary_base")]
+        [JsonPropertyName("secondary_base")]
+        [JsonInclude]
         public bool SecondaryBase { get; private set; }
 
-        [JsonProperty(PropertyName = "unk5")]
+        [JsonPropertyName("unk5")]
+        [JsonInclude]
         public bool Unknown5 { get; private set; }
 
-        [JsonProperty(PropertyName = "value")]
+        [JsonInclude]
         public bool Value { get; private set; }
     }
 }

--- a/src/LeagueToolkit/Meta/Dump/MetaDumpProperty.cs
+++ b/src/LeagueToolkit/Meta/Dump/MetaDumpProperty.cs
@@ -1,56 +1,81 @@
 ﻿using LeagueToolkit.IO.PropertyBin;
-using Newtonsoft.Json;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace LeagueToolkit.Meta.Dump
 {
     public sealed class MetaDumpProperty
     {
-        [JsonProperty(PropertyName = "other_class")] public string OtherClass { get; private set; }
-        [JsonProperty(PropertyName = "offset")] public uint Offset { get; private set; }
-        [JsonProperty(PropertyName = "bitmask")] public uint Bitmask { get; private set; }
+        [JsonPropertyName("other_class")]
+        [JsonInclude]
+        public string OtherClass { get; private set; }
+
+        [JsonInclude]
+        public uint Offset { get; private set; }
+
+        [JsonInclude]
+        public uint Bitmask { get; private set; }
 
         [JsonConverter(typeof(MetaDumpBinPropertyTypeJsonConverter))]
-        [JsonProperty(PropertyName = "value_type")] public BinPropertyType Type { get; private set; }
+        [JsonPropertyName("value_type")]
+        [JsonInclude]
+        public BinPropertyType Type { get; private set; }
 
-        [JsonProperty(PropertyName = "container")] public MetaDumpContainer Container { get; private set; }
-        [JsonProperty(PropertyName = "map")] public MetaDumpMap Map { get; private set; }
+        [JsonInclude]
+        public MetaDumpContainer Container { get; private set; }
+
+        [JsonInclude]
+        public MetaDumpMap Map { get; private set; }
     }
 
     public sealed class MetaDumpContainer
     {
-        [JsonProperty(PropertyName = "vtable")] public string VTable { get; private set; }
+        [JsonInclude]
+        public string VTable { get; private set; }
 
         [JsonConverter(typeof(MetaDumpBinPropertyTypeJsonConverter))]
-        [JsonProperty(PropertyName = "value_type")] public BinPropertyType Type { get; private set; }
+        [JsonPropertyName("value_type")]
+        [JsonInclude]
+        public BinPropertyType Type { get; private set; }
 
-        [JsonProperty(PropertyName = "value_size")] public uint ValueSize { get; private set; }
-        [JsonProperty(PropertyName = "fixed_size")] public int? FixedSize { get; private set; }
+        [JsonPropertyName("value_size")]
+        [JsonInclude]
+        public uint ValueSize { get; private set; }
+        [JsonPropertyName("fixed_size")]
+        [JsonInclude]
+        public int? FixedSize { get; private set; }
 
         [JsonConverter(typeof(MetaDumpContainerStorageTypeJsonConverter))]
-        [JsonProperty(PropertyName = "storage")] public MetaDumpContainerStorageType? Storage { get; private set; }
+        [JsonInclude]
+        public MetaDumpContainerStorageType? Storage { get; private set; }
     }
 
     public sealed class MetaDumpMap
     {
-        [JsonProperty(PropertyName = "vtable")] public string VTable { get; private set; }
-        
-        [JsonConverter(typeof(MetaDumpBinPropertyTypeJsonConverter))]
-        [JsonProperty(PropertyName = "key_type")] public BinPropertyType KeyType { get; private set; }
+        [JsonInclude]
+        public string VTable { get; private set; }
 
         [JsonConverter(typeof(MetaDumpBinPropertyTypeJsonConverter))]
-        [JsonProperty(PropertyName = "value_type")] public BinPropertyType ValueType { get; private set; }
+        [JsonPropertyName("key_type")]
+        [JsonInclude]
+        public BinPropertyType KeyType { get; private set; }
+
+        [JsonConverter(typeof(MetaDumpBinPropertyTypeJsonConverter))]
+        [JsonPropertyName("value_type")]
+        [JsonInclude]
+        public BinPropertyType ValueType { get; private set; }
 
         [JsonConverter(typeof(MetaDumpMapStorageTypeJsonConverter))]
-        [JsonProperty(PropertyName = "storage")] public MetaDumpMapStorageType Storage { get; private set; }
+        [JsonInclude]
+        public MetaDumpMapStorageType Storage { get; private set; }
     }
 
     public class MetaDumpBinPropertyTypeJsonConverter : JsonConverter<BinPropertyType>
     {
-        public override BinPropertyType ReadJson(JsonReader reader, Type objectType, [AllowNull] BinPropertyType existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override BinPropertyType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            string type = reader.Value as string;
+            string type = reader.GetString();
 
             return type switch
             {
@@ -85,7 +110,7 @@ namespace LeagueToolkit.Meta.Dump
             };
         }
 
-        public override void WriteJson(JsonWriter writer, [AllowNull] BinPropertyType value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, BinPropertyType value, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
         }
@@ -93,9 +118,9 @@ namespace LeagueToolkit.Meta.Dump
 
     public class MetaDumpMapStorageTypeJsonConverter : JsonConverter<MetaDumpMapStorageType>
     {
-        public override MetaDumpMapStorageType ReadJson(JsonReader reader, Type objectType, [AllowNull] MetaDumpMapStorageType existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override MetaDumpMapStorageType Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
         {
-            string storage = reader.Value as string;
+            string storage = reader.GetString();
             return storage switch
             {
                 "UnknownMap" => MetaDumpMapStorageType.UnknownMap,
@@ -106,7 +131,7 @@ namespace LeagueToolkit.Meta.Dump
             };
         }
 
-        public override void WriteJson(JsonWriter writer, [AllowNull] MetaDumpMapStorageType value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, MetaDumpMapStorageType metaDumpMapStorageType, JsonSerializerOptions jsonSerializerOptions)
         {
             throw new NotImplementedException();
         }
@@ -114,9 +139,9 @@ namespace LeagueToolkit.Meta.Dump
 
     public class MetaDumpContainerStorageTypeJsonConverter : JsonConverter<MetaDumpContainerStorageType?>
     {
-        public override MetaDumpContainerStorageType? ReadJson(JsonReader reader, Type objectType, [AllowNull] MetaDumpContainerStorageType? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        public override MetaDumpContainerStorageType? Read(ref Utf8JsonReader reader, Type objectType, JsonSerializerOptions options)
         {
-            string storage = reader.Value as string;
+            string storage = reader.GetString();
             return storage switch
             {
                 "UnknownVector" => MetaDumpContainerStorageType.UnknownVector,
@@ -129,7 +154,7 @@ namespace LeagueToolkit.Meta.Dump
             };
         }
 
-        public override void WriteJson(JsonWriter writer, [AllowNull] MetaDumpContainerStorageType? value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, MetaDumpContainerStorageType? value, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
         }

--- a/src/LeagueToolkit/packages.lock.json
+++ b/src/LeagueToolkit/packages.lock.json
@@ -29,12 +29,6 @@
           "System.Memory": "4.5.5"
         }
       },
-      "Newtonsoft.Json": {
-        "type": "Direct",
-        "requested": "[13.0.1, )",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
       "XXHash3.NET": {
         "type": "Direct",
         "requested": "[1.2.2, )",


### PR DESCRIPTION
Closes #194 

This also fixes a bug where floating point numbers could potentially be serialized as `0,1f` instead of `0.1f`.

I have tested this to work with a `meta_13.1.487.8994.json` generated from current pbe, and the resulting json file matches the one generated using Newtonsoft.Json.